### PR TITLE
feat(theme): introduce blue palette and update styles

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 const Footer = () => {
   return (
     <footer
-      className="wow fadeInUp relative z-10 bg-[#090E34] pt-20 lg:pt-[100px]"
+      className="wow fadeInUp relative z-10 bg-navyBlue pt-20 lg:pt-[100px]"
       data-wow-delay=".15s"
     >
       <div className="container">

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -13,7 +13,7 @@ body {
 }
 
 .sticky-menu #navbarToggler span {
-  @apply bg-dark dark:bg-white;
+  @apply bg-darkBlue dark:bg-white;
 }
 
 .sticky-menu #navbarCollapse li > a {
@@ -30,7 +30,7 @@ body {
 }
 
 .sticky-menu .signUpBtn {
-  @apply bg-primary hover:bg-dark text-white hover:text-white;
+  @apply bg-primary text-white hover:bg-lightBlueBright hover:text-white;
 }
 
 .navbarTogglerActive > span:nth-child(1) {
@@ -45,7 +45,7 @@ body {
 
 .blog-details,
 .blog-details p {
-  @apply text-body-color dark:text-dark-6 text-base leading-relaxed;
+  @apply text-base leading-relaxed text-body-color dark:text-dark-6;
 }
 
 .blog-details p {
@@ -53,7 +53,7 @@ body {
 }
 
 .blog-details strong {
-  @apply text-dark font-bold dark:text-white;
+  @apply font-bold text-dark dark:text-white;
 }
 
 .blog-details ul {
@@ -65,13 +65,13 @@ body {
 }
 
 .blog-details h1 {
-  @apply text-dark mb-8 text-3xl font-bold dark:text-white sm:text-4xl md:text-[40px] md:leading-[1.28];
+  @apply mb-8 text-3xl font-bold text-dark dark:text-white sm:text-4xl md:text-[40px] md:leading-[1.28];
 }
 
 .blog-details h2 {
-  @apply text-dark mb-8 text-2xl font-bold dark:text-white sm:text-3xl md:text-[35px] md:leading-[1.28];
+  @apply mb-8 text-2xl font-bold text-dark dark:text-white sm:text-3xl md:text-[35px] md:leading-[1.28];
 }
 
 .blog-details h3 {
-  @apply text-dark mb-6 text-2xl font-bold dark:text-white sm:text-[28px] sm:leading-[40px];
+  @apply mb-6 text-2xl font-bold text-dark dark:text-white sm:text-[28px] sm:leading-[40px];
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from "tailwindcss";
-const colors = require('tailwindcss/colors')
+const colors = require("tailwindcss/colors");
 
 const config: Config = {
   darkMode: "class",
@@ -12,7 +12,40 @@ const config: Config = {
     extend: {
       colors: {
         ...colors,
-        // primary: "#1A202C",
+        lightBlueBright: {
+          50: "#EAF4FE",
+          100: "#D5E9FE",
+          200: "#A6D2FC",
+          300: "#78BBFB",
+          400: "#4EA4F8",
+          500: "#3896F5",
+          600: "#2E7ED3",
+          700: "#2465AF",
+          800: "#1A4B8B",
+          900: "#113267",
+          DEFAULT: "#3896F5",
+        },
+        royalBlue: {
+          50: "#E9EDFF",
+          100: "#D4DAFF",
+          200: "#A8B5FF",
+          300: "#7C90FF",
+          400: "#506BFF",
+          500: "#1C56F0",
+          600: "#184AD4",
+          700: "#1339A8",
+          800: "#0E287C",
+          900: "#091950",
+          DEFAULT: "#1C56F0",
+        },
+        navyBlue: "#090F70",
+        darkBlue: "#252440",
+        primary: {
+          DEFAULT: "#1C56F0",
+          light: "#3896F5",
+          dark: "#090F70",
+          overlay: "#252440",
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- add custom blue palette to Tailwind theme
- use navy and dark blues in sticky menu and footer
- highlight sign-up button hover with light blue accent

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894dfe7bf308325bb7f314482250bec